### PR TITLE
README: add build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Debian/Ubuntu system, this can be installed by running
 
 ```sh
 $ sudo apt-get install make python-sphinx sphinx-rtd-theme-common
+$ sudo apt-get install python-pip
+$ sudo pip install sphinxcontrib-domaintools
 ```
 
 You may then build the html version by running


### PR DESCRIPTION
We are going to define a custom domain (oe), which needs the
domaintools python module.