### PR TITLE
Update setup.rst

### DIFF
--- a/source/setup.rst
+++ b/source/setup.rst
@@ -119,7 +119,7 @@ Something like
 
 .. code:: sh
 
-    ln -s $HOME/bin/oe ../src/bakery/oebakery/oe.py
+    ln -s ../src/bakery/oebakery/oe.py $HOME/bin/oe 
 
 (assuming you have the bakery source distribution in $HOME/src/bakery
 and have $HOME/bin in your $PATH)


### PR DESCRIPTION
correct the order of the arguments to ln

I believe that the link name comes last when using ln.